### PR TITLE
fix regex broken in v2.0.8.

### DIFF
--- a/lib/date/format.rb
+++ b/lib/date/format.rb
@@ -559,8 +559,8 @@ class Date
 	  e._cent ||= if val >= 69 then 19 else 20 end
 	when 'Z', /\A:{0,3}z/
 	  return unless str.sub!(/\A((?:gmt|utc?)?[-+]\d+(?:[,.:]\d+(?::\d+)?)?
-				    |(?-i:[[:alpha:].\\s]+)(?:standard|daylight)\\stime\\b
-				    |(?-i:[[:alpha:]]+)(?:\\sdst)?\\b
+				    |(?-i:[[:alpha:].\s]+)(?:standard|daylight)\stime\b
+				    |(?-i:[[:alpha:]]+)(?:\sdst)?\b
 				    )/ix, '')
 	  val = $1
 	  e.zone = val

--- a/spec/date/strptime_spec.rb
+++ b/spec/date/strptime_spec.rb
@@ -143,6 +143,9 @@ describe "Date#strptime" do
     Date.strptime("Sun Apr  9 00:00:00 +00:00 2000", "%+").should == Date.civil(2000, 4, 9)
     Date.strptime("Sun Apr  9 00:00:00 +00:00 2000", "%a %b %e %H:%M:%S %Z %Y").should == Date.civil(2000, 4, 9)
   end
+  it "parses a date with a Time Zone" do
+      Date.strptime('31 Dec 2014 11:12:13 UTC', '%d %b %Y %T %Z')
+  end
 
 end
 


### PR DESCRIPTION
Bad escaping of backslashes when not needed. This changed the regex completely.

Issues:
https://github.com/rubysl/rubysl-date/issues/9
https://github.com/rubinius/rubinius/issues/3258 
