### PR TITLE
Merge and share specs for Time, Date and DateTime #strftime.

### DIFF
--- a/lib/date/format.rb
+++ b/lib/date/format.rb
@@ -232,8 +232,8 @@ class Date
 	s.scan(/./) do |k|
 	  case k
 	  when '-'; f[:p] = '-'
-	  when '_'; f[:p] = "\s"
-	  when '0'; f[:p] = '0'
+	  when '_'; f[:p] = "\s" unless f[:p] == '-'
+	  when '0'; f[:p] = '0'  unless f[:p] == '-'
 	  when '^'; f[:u] = true
 	  when '#'; f[:x] = true
 	  end

--- a/spec/date/strftime_spec.rb
+++ b/spec/date/strftime_spec.rb
@@ -1,204 +1,40 @@
 require 'date'
+require File.expand_path('../../shared/strftime_for_date', __FILE__)
 
 describe "Date#strftime" do
+  before :all do
+    @new_date = lambda { |y,m,d| Date.civil(y,m,d) }
 
-  it "should be able to print the date" do
-    Date.civil(2000, 4, 6).strftime.should == "2000-04-06"
-    Date.civil(2000, 4, 6).strftime.should == Date.civil(2000, 4, 6).to_s
+    @date = Date.civil(2000, 4, 9)
   end
 
-  it "should be able to print the full day name" do
-    Date.civil(2000, 4, 6).strftime("%A").should == "Thursday"
+  it_behaves_like :strftime_date, :strftime
+
+  # Differences with Time
+  it "should be able to print the date with no argument" do
+    @date.strftime.should == "2000-04-09"
+    @date.strftime.should == @date.to_s
   end
 
-  it "should be able to print the short day name" do
-    Date.civil(2000, 4, 6).strftime("%a").should == "Thu"
+  # %Z is %:z for Date/DateTime
+  it "should be able to show the timezone with a : separator" do
+    @date.strftime("%Z").should == "+00:00"
   end
 
-  it "should be able to print the full month name" do
-    Date.civil(2000, 4, 6).strftime("%B").should == "April"
-  end
-
-  it "should be able to print the short month name" do
-    Date.civil(2000, 4, 6).strftime("%b").should == "Apr"
-    Date.civil(2000, 4, 6).strftime("%h").should == "Apr"
-    Date.civil(2000, 4, 6).strftime("%b").should == Date.civil(2000, 4, 6).strftime("%h")
-  end
-
-  it "should be able to print the century" do
-    Date.civil(2000, 4, 6).strftime("%C").should == "20"
-  end
-
-  it "should be able to print the month day with leading zeroes" do
-    Date.civil(2000, 4, 6).strftime("%d").should == "06"
-  end
-
-  it "should be able to print the month day with leading spaces" do
-    Date.civil(2000, 4, 6).strftime("%e").should == " 6"
-  end
-
-  it "should be able to print the commercial year with leading zeroes" do
-    Date.civil(2000, 4, 6).strftime("%G").should == "2000"
-    Date.civil( 200, 4, 6).strftime("%G").should == "0200"
-  end
-
-  it "should be able to print the commercial year with only two digits" do
-    Date.civil(2000, 4, 6).strftime("%g").should == "00"
-    Date.civil( 200, 4, 6).strftime("%g").should == "00"
-  end
-
-  it "should be able to print the hour with leading zeroes (hour is always 00)" do
-    Date.civil(2000, 4, 6).strftime("%H").should == "00"
-  end
-
-  it "should be able to print the hour in 12 hour notation with leading zeroes" do
-    Date.civil(2000, 4, 6).strftime("%I").should == "12"
-  end
-
-  it "should be able to print the year day with leading zeroes" do
-    Date.civil(2000, 4, 6).strftime("%j").should == "097"
-  end
-
-  it "should be able to print the hour in 24 hour notation with leading spaces" do
-    Date.civil(2000, 4, 6).strftime("%k").should == " 0"
-  end
-
-  it "should be able to print the hour in 12 hour notation with leading spaces" do
-    Date.civil(2000, 4, 6).strftime("%l").should == "12"
-  end
-
-  it "should be able to print the minutes with leading zeroes" do
-    Date.civil(2000, 4, 6).strftime("%M").should == "00"
-  end
-
-  it "should be able to print the month with leading zeroes" do
-    Date.civil(2000, 4, 6).strftime("%m").should == "04"
-  end
-
-  it "should be able to add a newline" do
-    Date.civil(2000, 4, 6).strftime("%n").should == "\n"
-  end
-
-  it "should be able to show AM/PM" do
-    Date.civil(2000, 4, 6).strftime("%P").should == "am"
-  end
-
-  it "should be able to show am/pm" do
-    Date.civil(2000, 4, 6).strftime("%p").should == "AM"
-  end
-
-  it "should be able to show the number of seconds with leading zeroes" do
-    Date.civil(2000, 4, 6).strftime("%S").should == "00"
-  end
-
-  it "should be able to show the number of seconds with leading zeroes" do
-    Date.civil(2000, 4, 6).strftime("%S").should == "00"
-  end
-
-  it "should be able to show the number of seconds since the unix epoch" do
-    Date.civil(2000, 4, 6).strftime("%s").should == "954979200"
-  end
-
-  it "should be able to add a tab" do
-    Date.civil(2000, 4, 6).strftime("%t").should == "\t"
-  end
-
-  it "should be able to show the week number with the week starting on sunday and monday" do
-    Date.civil(2000, 4, 6).strftime("%U").should == "14"
-    Date.civil(2000, 4, 6).strftime("%W").should == "14"
-    Date.civil(2000, 4, 6).strftime("%U").should == Date.civil(2000, 4, 6).strftime("%W")
-    Date.civil(2000, 4, 9).strftime("%U").should == "15"
-    Date.civil(2000, 4, 9).strftime("%W").should == "14"
-    Date.civil(2000, 4, 9).strftime("%U").should_not == Date.civil(2000, 4, 9).strftime("%W")
-  end
-
-  it "should be able to show the commercial week day" do
-    Date.civil(2000, 4,  9).strftime("%u").should == "7"
-    Date.civil(2000, 4, 10).strftime("%u").should == "1"
-  end
-
+  # %v is %e-%b-%Y for Date/DateTime
   it "should be able to show the commercial week" do
-    Date.civil(2000, 4,  9).strftime("%V").should == "14"
-    Date.civil(2000, 4, 10).strftime("%V").should == "15"
+    @date.strftime("%v").should == " 9-Apr-2000"
+    @date.strftime("%v").should == @date.strftime('%e-%b-%Y')
   end
 
-  it "should be able to show the week day" do
-    Date.civil(2000, 4,  9).strftime("%w").should == "0"
-    Date.civil(2000, 4, 10).strftime("%w").should == "1"
-  end
-
-  it "should be able to show the year in YYYY format" do
-    Date.civil(2000, 4,  9).strftime("%Y").should == "2000"
-  end
-
-  it "should be able to show the year in YY format" do
-    Date.civil(2000, 4,  9).strftime("%y").should == "00"
-  end
-
-  it "should be able to show the timezone of the date with a : separator" do
-    Date.civil(2000, 4,  9).strftime("%Z").should == "+00:00"
-  end
-
-  it "should be able to show the timezone of the date with a : separator" do
-    Date.civil(2000, 4,  9).strftime("%z").should == "+0000"
-  end
-
-  it "should be able to escape the % character" do
-    Date.civil(2000, 4,  9).strftime("%%").should == "%"
-  end
-
-  ############################
-  # Specs that combine stuff #
-  ############################
-
-  it "should be able to print the date in full" do
-    Date.civil(2000, 4, 6).strftime("%c").should == "Thu Apr  6 00:00:00 2000"
-    Date.civil(2000, 4, 6).strftime("%c").should == Date.civil(2000, 4, 6).strftime('%a %b %e %H:%M:%S %Y')
-  end
-
-  it "should be able to print the date with slashes" do
-    Date.civil(2000, 4, 6).strftime("%D").should == "04/06/00"
-    Date.civil(2000, 4, 6).strftime("%D").should == Date.civil(2000, 4, 6).strftime('%m/%d/%y')
-  end
-
-  it "should be able to print the date as YYYY-MM-DD" do
-    Date.civil(2000, 4, 6).strftime("%F").should == "2000-04-06"
-    Date.civil(2000, 4, 6).strftime("%F").should == Date.civil(2000, 4, 6).strftime('%Y-%m-%d')
-  end
-
-  it "should be able to show HH:MM" do
-    Date.civil(2000, 4, 6).strftime("%R").should == "00:00"
-    Date.civil(2000, 4, 6).strftime("%R").should == Date.civil(2000, 4, 6).strftime('%H:%M')
-  end
-
-  it "should be able to show HH:MM:SS AM/PM" do
-    Date.civil(2000, 4, 6).strftime("%r").should == "12:00:00 AM"
-    Date.civil(2000, 4, 6).strftime("%r").should == Date.civil(2000, 4, 6).strftime('%I:%M:%S %p')
-  end
-
-  it "should be able to show HH:MM:SS" do
-    Date.civil(2000, 4, 6).strftime("%T").should == "00:00:00"
-    Date.civil(2000, 4, 6).strftime("%T").should == Date.civil(2000, 4, 6).strftime('%H:%M:%S')
-  end
-
-  it "should be able to show the commercial week" do
-    Date.civil(2000, 4,  9).strftime("%v").should == " 9-Apr-2000"
-    Date.civil(2000, 4,  9).strftime("%v").should == Date.civil(2000, 4,  9).strftime('%e-%b-%Y')
-  end
-
-  it "should be able to show HH:MM:SS" do
-    Date.civil(2000, 4, 6).strftime("%X").should == "00:00:00"
-    Date.civil(2000, 4, 6).strftime("%X").should == Date.civil(2000, 4, 6).strftime('%H:%M:%S')
-  end
-
-  it "should be able to show MM/DD/YY" do
-    Date.civil(2000, 4, 6).strftime("%x").should == "04/06/00"
-    Date.civil(2000, 4, 6).strftime("%x").should == Date.civil(2000, 4, 6).strftime('%m/%d/%y')
+  # additional conversion specifiers only in Date/DateTime
+  it 'shows the number of milliseconds since epoch' do
+    DateTime.new(1970, 1, 1).strftime('%Q').should == "0"
+    @date.strftime("%Q").should == "955238400000"
   end
 
   it "should be able to show a full notation" do
-    Date.civil(2000, 4,  9).strftime("%+").should == "Sun Apr  9 00:00:00 +00:00 2000"
-    Date.civil(2000, 4,  9).strftime("%+").should == Date.civil(2000, 4,  9).strftime('%a %b %e %H:%M:%S %Z %Y')
+    @date.strftime("%+").should == "Sun Apr  9 00:00:00 +00:00 2000"
+    @date.strftime("%+").should == @date.strftime('%a %b %e %H:%M:%S %Z %Y')
   end
-
 end

--- a/spec/datetime/strftime_spec.rb
+++ b/spec/datetime/strftime_spec.rb
@@ -1,25 +1,51 @@
 require 'date'
+require File.expand_path('../../shared/strftime_for_date', __FILE__)
+require File.expand_path('../../shared/strftime_for_time', __FILE__)
 
-ruby_version_is "1.9.1" do
-  describe "DateTime#strftime" do
-    it "shows the number of fractional seconds with leading zeroes" do
-      DateTime.civil(2000, 4, 6).strftime("%N").should == "000000000"
-    end
+describe "DateTime#strftime" do
+  before :all do
+    @new_date = lambda { |y,m,d| DateTime.civil(y,m,d) }
+    @new_time = lambda { |*args| DateTime.civil(*args) }
+    @new_time_in_zone = lambda { |zone,offset,*args|
+      y, m, d, h, min, s = args
+      DateTime.new(y, m||1, d||1, h||0, min||0, s||0, Rational(offset, 24))
+    }
+    @new_time_with_offset = lambda { |y,m,d,h,min,s,offset|
+      DateTime.new(y,m,d,h,min,s, Rational(offset, 86_400))
+    }
 
-    it "shows the number of fractional seconds with leading zeroes to two decimal places" do
-      DateTime.civil(2000, 4, 6).strftime("%2N").should == "00"
-    end
+    @time = DateTime.civil(2001, 2, 3, 4, 5, 6)
+  end
 
-    it "shows the number of fractional milliseconds with leading zeroes" do
-      DateTime.civil(2000, 4, 6).strftime("%3N").should == "000"
-    end
+  it_behaves_like :strftime_date, :strftime
+  it_behaves_like :strftime_time, :strftime
 
-    it "shows the number of fractional microseconds with leading zeroes" do
-      DateTime.civil(2000, 4, 6).strftime("%6N").should == "000000"
-    end
+  # Differences with Time
+  it "should be able to print the datetime with no argument" do
+    @time.strftime.should == "2001-02-03T04:05:06+00:00"
+    @time.strftime.should == @time.to_s
+  end
 
-    it "shows the number of fractional nanoseconds with leading zeroes" do
-      DateTime.civil(2000, 4, 6).strftime("%9N").should == "000000000"
-    end
+  # %Z is %:z for Date/DateTime
+  it "should be able to show the timezone with a : separator" do
+    @time.strftime("%Z").should == "+00:00"
+  end
+
+  # %v is %e-%b-%Y for Date/DateTime
+  it "should be able to show the commercial week" do
+    @time.strftime("%v").should == " 3-Feb-2001"
+    @time.strftime("%v").should == @time.strftime('%e-%b-%Y')
+  end
+
+  # additional conversion specifiers only in Date/DateTime
+  it 'shows the number of milliseconds since epoch' do
+    DateTime.new(1970, 1, 1, 0, 0, 0).strftime("%Q").should == "0"
+    @time.strftime("%Q").should == "981173106000"
+    DateTime.civil(2001, 2, 3, 4, 5, Rational(6123, 1000)).strftime("%Q").should == "981173106123"
+  end
+
+  it "should be able to show a full notation" do
+    @time.strftime("%+").should == "Sat Feb  3 04:05:06 +00:00 2001"
+    @time.strftime("%+").should == @time.strftime('%a %b %e %H:%M:%S %Z %Y')
   end
 end

--- a/spec/shared/strftime_for_date.rb
+++ b/spec/shared/strftime_for_date.rb
@@ -258,19 +258,13 @@ describe :strftime_date, :shared => true do
     time.strftime('%_-^5h').should == 'FEB'
     time.strftime('%^ha').should == 'FEBa'
 
-    expected = {
-      "%10h" => '       Feb',
-      "%^10h" => '       FEB',
-      "%_10h" => '       Feb',
-      "%_010h" => '0000000Feb',
-      "%0_10h" => '       Feb',
-      "%0_-10h" => 'Feb',
-      "%0-_10h" => 'Feb'
-    }
-
-    ["%10h","%^10h","%_10h","%_010h","%0_10h","%0_-10h","%0-_10h"].each do |format|
-      time.strftime(format).should == expected[format]
-    end
+    time.strftime("%10h").should == '       Feb'
+    time.strftime("%^10h").should == '       FEB'
+    time.strftime("%_10h").should == '       Feb'
+    time.strftime("%_010h").should == '0000000Feb'
+    time.strftime("%0_10h").should == '       Feb'
+    time.strftime("%0_-10h").should == 'Feb'
+    time.strftime("%0-_10h").should == 'Feb'
   end
 
   it "supports the '-' modifier to drop leading zeros" do

--- a/spec/shared/strftime_for_date.rb
+++ b/spec/shared/strftime_for_date.rb
@@ -1,0 +1,288 @@
+# Shared for Time, Date and DateTime, testing only date components (smallest unit is day)
+# The reference version of this file lives in rubyspec's shared/time directory.
+
+describe :strftime_date, :shared => true do
+  before :all do
+    @d200_4_6 =   @new_date[200, 4, 6]
+    @d2000_4_6 =  @new_date[2000, 4, 6]
+    @d2000_4_9 =  @new_date[2000, 4, 9]
+    @d2000_4_10 = @new_date[2000, 4, 10]
+    @d2009_9_18 = @new_date[2009, 9, 18]
+  end
+
+  # Per conversion specifier, not combining
+  it "should be able to print the full day name" do
+    @d2000_4_6.strftime("%A").should == "Thursday"
+    @d2009_9_18.strftime('%A').should == 'Friday'
+  end
+
+  it "should be able to print the short day name" do
+    @d2000_4_6.strftime("%a").should == "Thu"
+    @d2009_9_18.strftime('%a').should == 'Fri'
+  end
+
+  it "should be able to print the full month name" do
+    @d2000_4_6.strftime("%B").should == "April"
+    @d2009_9_18.strftime('%B').should == 'September'
+  end
+
+  it "should be able to print the short month name" do
+    @d2000_4_6.strftime("%b").should == "Apr"
+    @d2000_4_6.strftime("%h").should == "Apr"
+    @d2000_4_6.strftime("%b").should == @d2000_4_6.strftime("%h")
+    @d2009_9_18.strftime('%b').should == 'Sep'
+  end
+
+  it "should be able to print the century" do
+    @d2000_4_6.strftime("%C").should == "20"
+  end
+
+  it "should be able to print the month day with leading zeroes" do
+    @d2000_4_6.strftime("%d").should == "06"
+    @d2009_9_18.strftime('%d').should == '18'
+  end
+
+  it "should be able to print the month day with leading spaces" do
+    @d2000_4_6.strftime("%e").should == " 6"
+  end
+
+  it "should be able to print the commercial year with leading zeroes" do
+    @d2000_4_6.strftime("%G").should == "2000"
+    @d200_4_6.strftime("%G").should == "0200"
+  end
+
+  it "should be able to print the commercial year with only two digits" do
+    @d2000_4_6.strftime("%g").should == "00"
+    @d200_4_6.strftime("%g").should == "00"
+  end
+
+  it "should be able to print the hour with leading zeroes (hour is always 00)" do
+    @d2000_4_6.strftime("%H").should == "00"
+  end
+
+  it "should be able to print the hour in 12 hour notation with leading zeroes" do
+    @d2000_4_6.strftime("%I").should == "12"
+  end
+
+  it "should be able to print the julian day with leading zeroes" do
+    @d2000_4_6.strftime("%j").should == "097"
+    @d2009_9_18.strftime('%j').should == '261'
+  end
+
+  it "should be able to print the hour in 24 hour notation with leading spaces" do
+    @d2000_4_6.strftime("%k").should == " 0"
+  end
+
+  it "should be able to print the hour in 12 hour notation with leading spaces" do
+    @d2000_4_6.strftime("%l").should == "12"
+  end
+
+  it "should be able to print the minutes with leading zeroes" do
+    @d2000_4_6.strftime("%M").should == "00"
+  end
+
+  it "should be able to print the month with leading zeroes" do
+    @d2000_4_6.strftime("%m").should == "04"
+    @d2009_9_18.strftime('%m').should == '09'
+  end
+
+  it "should be able to add a newline" do
+    @d2000_4_6.strftime("%n").should == "\n"
+  end
+
+  it "should be able to show AM/PM" do
+    @d2000_4_6.strftime("%P").should == "am"
+  end
+
+  it "should be able to show am/pm" do
+    @d2000_4_6.strftime("%p").should == "AM"
+  end
+
+  it "should be able to show the number of seconds with leading zeroes" do
+    @d2000_4_6.strftime("%S").should == "00"
+  end
+
+  it "should be able to show the number of seconds with leading zeroes" do
+    @d2000_4_6.strftime("%S").should == "00"
+  end
+
+  ruby_version_is "1.9" do
+    it "should be able to show the number of seconds since the unix epoch" do
+      @d2000_4_6.strftime("%s").should == "954979200"
+    end
+  end
+
+  it "should be able to add a tab" do
+    @d2000_4_6.strftime("%t").should == "\t"
+  end
+
+  it "should be able to show the week number with the week starting on Sunday (%U) and Monday (%W)" do
+    @d2000_4_6.strftime("%U").should == "14"  # Thursday
+    @d2000_4_6.strftime("%W").should == "14"
+
+    @d2000_4_9.strftime("%U").should == "15"  # Sunday
+    @d2000_4_9.strftime("%W").should == "14"
+
+    @d2000_4_10.strftime("%U").should == "15" # Monday
+    @d2000_4_10.strftime("%W").should == "15"
+
+    # start of the year
+    saturday_first = @new_date[2000,1,1]
+    saturday_first.strftime("%U").should == "00"
+    saturday_first.strftime("%W").should == "00"
+
+    sunday_second = @new_date[2000,1,2]
+    sunday_second.strftime("%U").should == "01"
+    sunday_second.strftime("%W").should == "00"
+
+    monday_third = @new_date[2000,1,3]
+    monday_third.strftime("%U").should == "01"
+    monday_third.strftime("%W").should == "01"
+
+    sunday_9th = @new_date[2000,1,9]
+    sunday_9th.strftime("%U").should == "02"
+    sunday_9th.strftime("%W").should == "01"
+
+    monday_10th = @new_date[2000,1,10]
+    monday_10th.strftime("%U").should == "02"
+    monday_10th.strftime("%W").should == "02"
+
+    # middle of the year
+    some_sunday = @new_date[2000,8,6]
+    some_sunday.strftime("%U").should == "32"
+    some_sunday.strftime("%W").should == "31"
+    some_monday = @new_date[2000,8,7]
+    some_monday.strftime("%U").should == "32"
+    some_monday.strftime("%W").should == "32"
+
+    # end of year, and start of next one
+    saturday_30th = @new_date[2000,12,30]
+    saturday_30th.strftime("%U").should == "52"
+    saturday_30th.strftime("%W").should == "52"
+
+    sunday_last = @new_date[2000,12,31]
+    sunday_last.strftime("%U").should == "53"
+    sunday_last.strftime("%W").should == "52"
+
+    monday_first = @new_date[2001,1,1]
+    monday_first.strftime("%U").should == "00"
+    monday_first.strftime("%W").should == "01"
+  end
+
+  it "should be able to show the commercial week day" do
+    @d2000_4_9.strftime("%u").should == "7"
+    @d2000_4_10.strftime("%u").should == "1"
+  end
+
+  it "should be able to show the commercial week" do
+    @d2000_4_9.strftime("%V").should == "14"
+    @d2000_4_10.strftime("%V").should == "15"
+  end
+
+  # %W: see %U
+
+  it "should be able to show the week day" do
+    @d2000_4_9.strftime("%w").should == "0"
+    @d2000_4_10.strftime("%w").should == "1"
+    @d2009_9_18.strftime('%w').should == '5'
+  end
+
+  it "should be able to show the year in YYYY format" do
+    @d2000_4_9.strftime("%Y").should == "2000"
+    @d2009_9_18.strftime('%Y').should == '2009'
+  end
+
+  it "should be able to show the year in YY format" do
+    @d2000_4_9.strftime("%y").should == "00"
+    @d2009_9_18.strftime('%y').should == '09'
+  end
+
+  it "should be able to show the timezone of the date with a : separator" do
+    @d2000_4_9.strftime("%z").should == "+0000"
+  end
+
+  it "should be able to escape the % character" do
+    @d2000_4_9.strftime("%%").should == "%"
+  end
+
+  # Combining conversion specifiers
+  it "should be able to print the date in full" do
+    @d2000_4_6.strftime("%c").should == "Thu Apr  6 00:00:00 2000"
+    @d2000_4_6.strftime("%c").should == @d2000_4_6.strftime('%a %b %e %H:%M:%S %Y')
+  end
+
+  it "should be able to print the date with slashes" do
+    @d2000_4_6.strftime("%D").should == "04/06/00"
+    @d2000_4_6.strftime("%D").should == @d2000_4_6.strftime('%m/%d/%y')
+  end
+
+  it "should be able to print the date as YYYY-MM-DD" do
+    @d2000_4_6.strftime("%F").should == "2000-04-06"
+    @d2000_4_6.strftime("%F").should == @d2000_4_6.strftime('%Y-%m-%d')
+  end
+
+  it "should be able to show HH:MM" do
+    @d2000_4_6.strftime("%R").should == "00:00"
+    @d2000_4_6.strftime("%R").should == @d2000_4_6.strftime('%H:%M')
+  end
+
+  it "should be able to show HH:MM:SS AM/PM" do
+    @d2000_4_6.strftime("%r").should == "12:00:00 AM"
+    @d2000_4_6.strftime("%r").should == @d2000_4_6.strftime('%I:%M:%S %p')
+  end
+
+  it "should be able to show HH:MM:SS" do
+    @d2000_4_6.strftime("%T").should == "00:00:00"
+    @d2000_4_6.strftime("%T").should == @d2000_4_6.strftime('%H:%M:%S')
+  end
+
+  it "should be able to show HH:MM:SS" do
+    @d2000_4_6.strftime("%X").should == "00:00:00"
+    @d2000_4_6.strftime("%X").should == @d2000_4_6.strftime('%H:%M:%S')
+  end
+
+  it "should be able to show MM/DD/YY" do
+    @d2000_4_6.strftime("%x").should == "04/06/00"
+    @d2000_4_6.strftime("%x").should == @d2000_4_6.strftime('%m/%d/%y')
+  end
+
+  # GNU modificators
+  it "supports GNU modificators" do
+    time = @new_date[2001, 2, 3]
+
+    time.strftime('%^h').should == 'FEB'
+    time.strftime('%^_5h').should == '  FEB'
+    time.strftime('%0^5h').should == '00FEB'
+    time.strftime('%04m').should == '0002'
+    time.strftime('%0-^5h').should == 'FEB'
+    time.strftime('%_-^5h').should == 'FEB'
+    time.strftime('%^ha').should == 'FEBa'
+
+    expected = {
+      "%10h" => '       Feb',
+      "%^10h" => '       FEB',
+      "%_10h" => '       Feb',
+      "%_010h" => '0000000Feb',
+      "%0_10h" => '       Feb',
+      "%0_-10h" => 'Feb',
+      "%0-_10h" => 'Feb'
+    }
+
+    ["%10h","%^10h","%_10h","%_010h","%0_10h","%0_-10h","%0-_10h"].each do |format|
+      time.strftime(format).should == expected[format]
+    end
+  end
+
+  it "supports the '-' modifier to drop leading zeros" do
+    @new_date[2001,3,22].strftime("%-m/%-d/%-y").should == "3/22/1"
+  end
+
+  with_feature :encoding do
+    it "passes the format string's encoding to the result string" do
+      result = @new_date[2010,3,8].strftime("%d. März %Y")
+
+      result.encoding.should == Encoding::UTF_8
+      result.should == "08. März 2010"
+    end
+  end
+end

--- a/spec/shared/strftime_for_time.rb
+++ b/spec/shared/strftime_for_time.rb
@@ -128,10 +128,6 @@ describe :strftime_time, :shared => true do
     it "formats a time with fixed offset as '+/-HH:MM:SS' with '::' specifier" do
       @new_time_with_offset[2012, 1, 1, 0, 0, 0, 3665].strftime("%::z").should == "+01:01:05"
     end
-
-    it "rounds fixed offset to the nearest second" do
-      @new_time_with_offset[2012, 1, 1, 0, 0, 0, Rational(36645, 10)].strftime("%::z").should == "+01:01:05"
-    end
   end
 
   # Combining conversion specifiers

--- a/spec/shared/strftime_for_time.rb
+++ b/spec/shared/strftime_for_time.rb
@@ -1,0 +1,178 @@
+# Shared for Time and DateTime, testing only time components (hours, minutes, seconds and smaller)
+# The reference version of this file lives in rubyspec's shared/time directory.
+
+describe :strftime_time, :shared => true do
+  before :all do
+    @time = @new_time[2001, 2, 3, 4, 5, 6]
+  end
+
+  it "formats time according to the directives in the given format string" do
+    @new_time[1970, 1, 1].strftime("There is %M minutes in epoch").should == "There is 00 minutes in epoch"
+  end
+
+  # Per conversion specifier, not combining
+  it "returns the 24-based hour with %H" do
+    time = @new_time[2009, 9, 18, 18, 0, 0]
+    time.strftime('%H').should == '18'
+  end
+
+  it "returns the 12-based hour with %I" do
+    time = @new_time[2009, 9, 18, 18, 0, 0]
+    time.strftime('%I').should == '06'
+  end
+
+  it "supports 24-hr formatting with %l" do
+    time = @new_time[2004, 8, 26, 22, 38, 3]
+    time.strftime("%k").should == "22"
+    morning_time = @new_time[2004, 8, 26, 6, 38, 3]
+    morning_time.strftime("%k").should == " 6"
+  end
+
+  describe "with %L" do
+    it "formats the milliseconds of of the second" do
+      @new_time[2009, 1, 1, 0, 0, Rational(100, 1000)].strftime("%L").should == "100"
+      @new_time[2009, 1, 1, 0, 0, Rational(10, 1000)].strftime("%L").should == "010"
+      @new_time[2009, 1, 1, 0, 0, Rational(1, 1000)].strftime("%L").should == "001"
+      @new_time[2009, 1, 1, 0, 0, Rational(1, 10000)].strftime("%L").should == "000"
+    end
+  end
+
+  it "supports 12-hr formatting with %l" do
+    time = @new_time[2004, 8, 26, 22, 38, 3]
+    time.strftime('%l').should == '10'
+    morning_time = @new_time[2004, 8, 26, 6, 38, 3]
+    morning_time.strftime('%l').should == ' 6'
+  end
+
+  it "returns the minute with %M" do
+    time = @new_time[2009, 9, 18, 12, 6, 0]
+    time.strftime('%M').should == '06'
+  end
+
+  describe "with %N" do
+    it "formats the nanoseconds of the second with %N" do
+      @new_time[2000, 4, 6, 0, 0, Rational(1234560, 1_000_000_000)].strftime("%N").should == "001234560"
+    end
+
+    it "formats the milliseconds of the second with %3N" do
+      @new_time[2000, 4, 6, 0, 0, Rational(50, 1000)].strftime("%3N").should == "050"
+    end
+
+    it "formats the microseconds of the second with %6N" do
+      @new_time[2000, 4, 6, 0, 0, Rational(42, 1000)].strftime("%6N").should == "042000"
+    end
+
+    it "formats the nanoseconds of the second with %9N" do
+      @new_time[2000, 4, 6, 0, 0, Rational(1234, 1_000_000)].strftime("%9N").should == "001234000"
+    end
+
+    it "formats the picoseconds of the second with %12N" do
+      @new_time[2000, 4, 6, 0, 0, Rational(999999999999, 1000_000_000_000)].strftime("%12N").should == "999999999999"
+    end
+  end
+
+  it "supports am/pm formatting with %P" do
+    time = @new_time[2004, 8, 26, 22, 38, 3]
+    time.strftime('%P').should == 'pm'
+    time = @new_time[2004, 8, 26, 11, 38, 3]
+    time.strftime('%P').should == 'am'
+  end
+
+  it "supports AM/PM formatting with %p" do
+    time = @new_time[2004, 8, 26, 22, 38, 3]
+    time.strftime('%p').should == 'PM'
+    time = @new_time[2004, 8, 26, 11, 38, 3]
+    time.strftime('%p').should == 'AM'
+  end
+
+  it "returns the second with %S" do
+    time = @new_time[2009, 9, 18, 12, 0, 6]
+    time.strftime('%S').should == '06'
+  end
+
+  it "should be able to show the number of seconds since the unix epoch" do
+    @new_time_in_zone["GMT", 0, 2005].strftime("%s").should == "1104537600"
+  end
+
+  it "returns the timezone with %Z" do
+    time = @new_time[2009, 9, 18, 12, 0, 0]
+    zone = time.zone
+    time.strftime("%Z").should == zone
+  end
+
+  describe "with %z" do
+    it "formats a UTC time offset as '+0000'" do
+      @new_time_in_zone["GMT", 0, 2005].strftime("%z").should == "+0000"
+    end
+
+    it "formats a local time with positive UTC offset as '+HHMM'" do
+      @new_time_in_zone["CET", 1, 2005].strftime("%z").should == "+0100"
+    end
+
+    it "formats a local time with negative UTC offset as '-HHMM'" do
+      @new_time_in_zone["PST", -8, 2005].strftime("%z").should == "-0800"
+    end
+
+    it "formats a time with fixed positive offset as '+HHMM'" do
+      @new_time_with_offset[2012, 1, 1, 0, 0, 0, 3660].strftime("%z").should == "+0101"
+    end
+
+    it "formats a time with fixed negative offset as '-HHMM'" do
+      @new_time_with_offset[2012, 1, 1, 0, 0, 0, -3660].strftime("%z").should == "-0101"
+    end
+
+    it "formats a time with fixed offset as '+/-HH:MM' with ':' specifier" do
+      @new_time_with_offset[2012, 1, 1, 0, 0, 0, 3660].strftime("%:z").should == "+01:01"
+    end
+
+    it "formats a time with fixed offset as '+/-HH:MM:SS' with '::' specifier" do
+      @new_time_with_offset[2012, 1, 1, 0, 0, 0, 3665].strftime("%::z").should == "+01:01:05"
+    end
+
+    it "rounds fixed offset to the nearest second" do
+      @new_time_with_offset[2012, 1, 1, 0, 0, 0, Rational(36645, 10)].strftime("%::z").should == "+01:01:05"
+    end
+  end
+
+  # Combining conversion specifiers
+  it "should be able to print the time in full" do
+    @time.strftime("%c").should == "Sat Feb  3 04:05:06 2001"
+    @time.strftime("%c").should == @time.strftime('%a %b %e %H:%M:%S %Y')
+  end
+
+  it "should be able to show HH:MM" do
+    @time.strftime("%R").should == "04:05"
+    @time.strftime("%R").should == @time.strftime('%H:%M')
+  end
+
+  it "should be able to show HH:MM:SS AM/PM" do
+    @time.strftime("%r").should == "04:05:06 AM"
+    @time.strftime("%r").should == @time.strftime('%I:%M:%S %p')
+  end
+
+  it "supports HH:MM:SS formatting with %T" do
+    @time.strftime('%T').should == '04:05:06'
+    @time.strftime('%T').should == @time.strftime('%H:%M:%S')
+  end
+
+  it "supports HH:MM:SS formatting with %X" do
+    @time.strftime('%X').should == '04:05:06'
+    @time.strftime('%X').should == @time.strftime('%H:%M:%S')
+  end
+
+  # GNU modificators
+  it "supports the '-' modifier to drop leading zeros" do
+    time = @new_time[2001,1,1,14,01,42]
+    time.strftime("%-m/%-d/%-y %-I:%-M %p").should == "1/1/1 2:1 PM"
+
+    time = @new_time[2010,10,10,12,10,42]
+    time.strftime("%-m/%-d/%-y %-I:%-M %p").should == "10/10/10 12:10 PM"
+  end
+
+  it "supports the '-' modifier for padded format directives" do
+    time = @new_time[2010, 8, 8, 8, 10, 42]
+    time.strftime("%-e").should == "8"
+    time.strftime("%-k%p").should == "8AM"
+    time.strftime("%-l%p").should == "8AM"
+  end
+end


### PR DESCRIPTION
* Separated date and time components.
* Improved a couple specs along the way.
* There are now specs for every documented conversion specifier.
* Originially written in https://github.com/rubyspec/rubyspec/pull/241.

See https://github.com/rubyspec/rubyspec/pull/313.